### PR TITLE
fix: ci server image push

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -151,6 +151,8 @@ jobs:
     name: Build & Push Server Container
     needs: [test-native, check-wasm, lint-native, lint-wasm]
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -163,7 +165,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Metadata


### PR DESCRIPTION
Give `server-container` permission to write to packages and login as repository owner instead of actor.